### PR TITLE
2017 04 18 use distillery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-![travis build status](https://travis-ci.org/influenza/pfds.svg?branch=master)
-
-
 # Purely Functional Data Structures
+
+![travis build status](https://travis-ci.org/influenza/pfds.svg?branch=master)
 
 This repository is where I collect scratch modules used while working through
 Chris Okasaki's [Purely Functional Data Structures](https://www.amazon.com/Purely-Functional-Structures-Chris-Okasaki/dp/0521663504)

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,4 +1,6 @@
-config :cheese_me, CheeseMeApplication,
+use Mix.Config
+
+config :cheese_me,
   http: [port: 8080],
   url: [host: "cheezy.neil-concepts.com"],
   cache_static_manifest: "priv/static/manifest.json",

--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule CheeseMe.Mixfile do
       {:cowboy, "~> 1.0.0"},
       {:plug, "~> 1.0"},
       {:slack, "~> 0.11.0"},
-      {:exrm, "~> 1.0.8"}
+      {:distillery, "~> 1.0"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -3,6 +3,7 @@
   "cf": {:hex, :cf, "0.2.2", "7f2913fff90abcabd0f489896cfeb0b0674f6c8df6c10b17a83175448029896c", [:rebar3], []},
   "cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:make, :rebar], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
+  "distillery": {:hex, :distillery, "1.3.4", "78c66a4cf8944c5bd501e785fbdf73b2fccbfcd84839b9446e8587b7ac91f6ad", [:mix], []},
   "erlware_commons": {:hex, :erlware_commons, "1.0.0", "087467de5833c0bb5b3ccdd387f9e9c1fb816a75b7a709629bf24b5ed3246c51", [:rebar3], [{:cf, "0.2.2", [hex: :cf, optional: false]}]},
   "exjsx": {:hex, :exjsx, "3.2.1", "1bc5bf1e4fd249104178f0885030bcd75a4526f4d2a1e976f4b428d347614f0f", [:mix], [{:jsx, "~> 2.8.0", [hex: :jsx, optional: false]}]},
   "exrm": {:hex, :exrm, "1.0.8", "5aa8990cdfe300282828b02cefdc339e235f7916388ce99f9a1f926a9271a45d", [:mix], [{:relx, "~> 3.5", [hex: :relx, optional: false]}]},


### PR DESCRIPTION
Remove exrm, use Distillery. This is the next-gen release management tool and works on OS X (unlike the latest exrm).